### PR TITLE
Correct listener names

### DIFF
--- a/ansible/group_vars/live_Application_STAFFWARE
+++ b/ansible/group_vars/live_Application_STAFFWARE
@@ -1,2 +1,2 @@
 oracle_logs_ora_sid: "STAFLIVE"
-oracle_logs_ora_listener: "listener1210_1521"
+oracle_logs_ora_listener: "listener"

--- a/ansible/group_vars/live_Application_STAFFWARE
+++ b/ansible/group_vars/live_Application_STAFFWARE
@@ -1,2 +1,2 @@
 oracle_logs_ora_sid: "STAFLIVE"
-oracle_logs_ora_listener: "listener1210_1522"
+oracle_logs_ora_listener: "listener1210_1521"

--- a/ansible/group_vars/staging_Application_STAFFWARE
+++ b/ansible/group_vars/staging_Application_STAFFWARE
@@ -1,2 +1,2 @@
 oracle_logs_ora_sid: "STAFFSTG"
-oracle_logs_ora_listener: "listener1210_1522"
+oracle_logs_ora_listener: "listener"


### PR DESCRIPTION
Corrected listener names for `STAFFWARE` in staging and live.