### PR TITLE
Update CloudWatch for Oracle Multi-Line Logs

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -2,12 +2,15 @@ oracle_logs_log_group_prefix: "{{ oracle_logs_service_name }}/oracle"
 oracle_logs_log_export_list:
   - name: "alert"
     path: "/u01/app/oracle/diag/rdbms/{{ oracle_logs_ora_sid|lower }}/{{ oracle_logs_ora_sid }}/trace/alert_{{ oracle_logs_ora_sid }}.log"
+    timestamp_format: "%a %b %d %H:%M:%S %Y"
   - name: "audit"
     path: "/u01/app/oracle/admin/{{ oracle_logs_ora_sid }}/adump/{{ oracle_logs_ora_sid }}_ora_*.aud"
+    timestamp_format: "%a %b %d %H:%M:%S %Y"
   - name: "listener"
     path: "/u01/app/oracle/diag/tnslsnr/{{ ansible_facts['hostname'] }}/{{ oracle_logs_ora_listener }}/alert/log.xml"
   - name: "trace"
     path: "/u01/app/oracle/diag/rdbms/{{ oracle_logs_ora_sid|lower }}/{{ oracle_logs_ora_sid }}/trace/{{ oracle_logs_ora_sid }}_ora_*.trc"
+    timestamp_format: "*** %Y-%m-%d %H:%M:%f"
 
 dbaops_scripts:
   - script_name: "S3_rman_arch_backup.ksh"

--- a/ansible/roles/oracle-logs/templates/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_oracle_logs.json.j2
+++ b/ansible/roles/oracle-logs/templates/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_oracle_logs.json.j2
@@ -4,10 +4,14 @@
       "files": {
         "collect_list": [
 {% for logfile in oracle_logs_log_export_list %}          {
-              "file_path": "{{ logfile['path'] }}",
-              "log_group_name": "{{ oracle_logs_log_group_prefix }}/{{ logfile['name'] }}",
-              "log_stream_name": "{{ ansible_facts['hostname'] }}",
-              "timezone": "Local"
+            "file_path": "{{ logfile['path'] }}",
+            "log_group_name": "{{ oracle_logs_log_group_prefix }}/{{ logfile['name'] }}",
+            "log_stream_name": "{{ ansible_facts['hostname'] }}",
+{% if 'timestamp_format' in logfile %}
+            "timestamp_format": "{{ logfile['timestamp_format'] }}",
+            "multi_line_start_pattern": "{timestamp_format}",
+{% endif %}
+            "timezone": "Local"
           }{% if not loop.last %},
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Updated cloudwatch template to allow for optional `timestamp_format` strings when handling multi-line logs
Updated `group_vars` to define appropriate `timestamp_format` strings

Resolves: CM-1469